### PR TITLE
Devcontainer setup

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.1"
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,7 @@
 {
   "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.2",
   "customizations": {
-    "postCreateCommand": "ansible-galaxy collection install cisco.ios",
+    "postCreateCommand": "ansible-galaxy collection install cisco.ios cisco.nxos",
     "extensions": [
       "ms-azuretools.vscode-docker",
       "redhat.vscode-yaml",

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.2",
+  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:latest",
   "customizations": {
     "postCreateCommand": "ansible-galaxy collection install cisco.ios cisco.nxos",
     "extensions": [

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,3 +1,12 @@
 {
-  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.2"
+  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.2",
+  "customizations": {
+    "postCreateCommand": "ansible-galaxy collection install cisco.ios",
+    "extensions": [
+      "ms-azuretools.vscode-docker",
+      "redhat.vscode-yaml",
+      "vscoss.vscode-ansible",
+      "gamunu.opentofu"
+    ]
+  }
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,3 +1,3 @@
 {
-  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.1"
+  "image": "ghcr.io/colinjlacy/tofu-ansible-dev-container:0.0.2"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,6 @@
 crash.log
 crash.*.log
 
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
-*.tfvars
-*.tfvars.json
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
@@ -37,3 +31,5 @@ override.tf.json
 .terraformrc
 terraform.rc
 .terraform.lock.hcl
+
+.idea

--- a/terraform/cloud.tf
+++ b/terraform/cloud.tf
@@ -1,12 +1,8 @@
-#Some env variables
-variable "my_public_ip" {
-  type = string
-}
 
 
 # Cloud VPC
 resource "aws_vpc" "production" {
-  cidr_block = "10.10.0.0/16"
+  cidr_block = var.aws_cidr
 
   tags = {
     Name = "Production-cloud-vpc"
@@ -16,8 +12,8 @@ resource "aws_vpc" "production" {
 #One subnet per AZ
 resource "aws_subnet" "prod-subnet1" {
   vpc_id               = aws_vpc.production.id
-  cidr_block           = "10.10.1.0/24"
-  availability_zone_id = "euc1-az1"
+  cidr_block           = var.aws_cidr_subnet1
+  availability_zone_id = var.aws_az1
 
   tags = {
     Name = "subnet-Production-1"
@@ -25,8 +21,8 @@ resource "aws_subnet" "prod-subnet1" {
 }
 resource "aws_subnet" "prod-subnet2" {
   vpc_id               = aws_vpc.production.id
-  cidr_block           = "10.10.2.0/24"
-  availability_zone_id = "euc1-az2"
+  cidr_block           = var.aws_cidr_subnet2
+  availability_zone_id = var.aws_az2
 
   tags = {
     Name = "subnet-Production-2"
@@ -34,8 +30,8 @@ resource "aws_subnet" "prod-subnet2" {
 }
 resource "aws_subnet" "prod-subnet3" {
   vpc_id               = aws_vpc.production.id
-  cidr_block           = "10.10.3.0/24"
-  availability_zone_id = "euc1-az3"
+  cidr_block           = var.aws_cidr_subnet3
+  availability_zone_id = var.aws_az3
 
   tags = {
     Name = "subnet-Production-3"

--- a/terraform/on-prem.tf
+++ b/terraform/on-prem.tf
@@ -13,47 +13,52 @@ resource "nxos_feature_interface_vlan" "example" {
 
 #interface towards CSR1000 - R1
 resource "nxos_ipv4_vrf" "example" {
-  name = "default"
+  name = var.ipv4_vrf_name
 }
 resource "nxos_physical_interface" "r1-spine" {
-  interface_id             = "eth1/2"
-  layer                    = "Layer3"
+  interface_id             = var.physical_interface_id
+  layer                    = var.physical_interface_layer
+  admin_state              = "up"
 }
 resource "nxos_ipv4_interface" "r1-spine" {
-  vrf          = "default"
-  interface_id = "eth1/2"
+  vrf          = nxos_ipv4_vrf.example.name
+  interface_id = nxos_physical_interface.r1-spine.interface_id
+
+  depends_on = [nxos_physical_interface.r1-spine]
 }
 resource "nxos_ipv4_interface_address" "r1-spine" {
-  vrf          = "default"
-  interface_id = "eth1/2"
-  address      = "172.16.0.1/31"
+  vrf          = nxos_ipv4_vrf.example.name
+  interface_id = nxos_physical_interface.r1-spine.interface_id
+  address      = var.physical_interface_address
   type         = "primary"
+
+  depends_on = [nxos_ipv4_interface.r1-spine]
 }
 
 #BGP peer with R1
 resource "nxos_bgp_peer" "r1-peer" {
-  asn               = "65010"
-  vrf               = "default"
-  address           = "172.16.0.0"
-  remote_asn        = "65010"
+  asn               = var.bgp_asn
+  vrf               = nxos_ipv4_vrf.example.name
+  address           = var.bgp_peer_address
+  remote_asn        = var.bgp_asn
 }
 resource "nxos_bgp" "example" {
   admin_state = "enabled"
 }
 resource "nxos_bgp_instance" "example" {
-  admin_state             = "enabled"
-  asn                     = "65010"
+  admin_state             = nxos_bgp.example.admin_state
+  asn                     = nxos_bgp_peer.r1-peer.asn
 }
 resource "nxos_bgp_address_family" "example" {
-  asn                          = "65010"
-  vrf                          = "default"
-  address_family               = "ipv4-ucast"
+  asn                          = nxos_bgp_peer.r1-peer.asn
+  vrf                          = nxos_ipv4_vrf.example.name
+  address_family               = var.bgp_address_family
 }
 resource "nxos_bgp_peer_address_family" "example" {
-  asn                     = "65010"
-  vrf                     = "default"
-  address                 = "172.16.0.0"
-  address_family          = "ipv4-ucast"
+  asn                     = nxos_bgp_peer.r1-peer.asn
+  vrf                     = nxos_ipv4_vrf.example.name
+  address                 = nxos_bgp_peer.r1-peer.address
+  address_family          = nxos_bgp_address_family.example.address_family
 }
 
 #NO WAY TO CREATE VLAN VIA TERRAFORM
@@ -61,10 +66,14 @@ resource "nxos_bgp_peer_address_family" "example" {
 resource "nxos_svi_interface" "vlan10" {
   interface_id = "vlan10"
   admin_state  = "up"
+
+  depends_on = [nxos_feature_interface_vlan.example]
 }
 resource "nxos_svi_interface" "vlan20" {
   interface_id = "vlan20"
   admin_state  = "up"
+
+  depends_on = [nxos_feature_interface_vlan.example]
 }
 #This one does not work!! How can I put ip addr to the svi????
 # ALSO how can I advertise the prefix via BGP???

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,17 @@
+output "tunnel1_outside_ip" {
+  value = aws_vpn_connection.prod-vpn.tunnel1_address
+}
+
+output "tunnel1_key" {
+  value = aws_vpn_connection.prod-vpn.tunnel1_preshared_key
+  sensitive = true
+}
+
+output "tunnel2_outside_ip" {
+  value = aws_vpn_connection.prod-vpn.tunnel2_address
+}
+
+output "tunnel2_key" {
+  value = aws_vpn_connection.prod-vpn.tunnel2_preshared_key
+  sensitive = true
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -15,10 +15,10 @@ terraform {
 provider "nxos" {
   username = "admin"
   password = "cisco"
-  url      = "https://192.168.201.10"
+  url      = var.nxos_url
 }
 
 
 provider "aws" {
-  region = "eu-central-1"
+  region = var.aws_region
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,0 +1,94 @@
+#Some env variables
+variable "my_public_ip" {
+  type = string
+}
+
+# NXOS variables
+variable "nxos_username" {
+  type = string
+  default = "admin"
+}
+
+variable "nxos_password" {
+  type = string
+  default = "cisco"
+}
+
+variable "nxos_url" {
+  type    = string
+  default = "https://192.168.0.101"
+}
+
+variable "ipv4_vrf_name" {
+    type    = string
+    default = "default"
+}
+
+variable "physical_interface_id" {
+    type    = string
+    default = "eth1/2"
+}
+
+variable "physical_interface_layer" {
+    type    = string
+    default = "Layer3"
+}
+
+variable "physical_interface_address" {
+    type    = string
+    default = "172.16.0.1/31"
+}
+
+variable "bgp_asn" {
+    type    = string
+    default = "65010"
+}
+
+variable "bgp_peer_address" {
+    type    = string
+    default = "172.16.0.0"
+}
+
+variable "bgp_address_family" {
+    type    = string
+    default = "ipv4-ucast"
+}
+
+# AWS variables
+variable "aws_region" {
+  type = string
+  default = "us-east-1"
+}
+
+variable "aws_az1" {
+  type = string
+  default = "use1-az1"
+}
+
+variable "aws_az2" {
+  type = string
+}
+
+variable "aws_az3" {
+  type = string
+}
+
+variable "aws_cidr" {
+  type    = string
+  default = "10.10.0.0/16"
+}
+
+variable "aws_cidr_subnet1" {
+  type    = string
+  default = "10.10.0.0/18"
+}
+
+variable "aws_cidr_subnet2" {
+  type    = string
+  default = "10.10.64.0/18"
+}
+
+variable "aws_cidr_subnet3" {
+  type    = string
+  default = "10.10.128.0/18"
+}

--- a/terraform/vars/eu.tfvars
+++ b/terraform/vars/eu.tfvars
@@ -1,0 +1,4 @@
+aws_region = "eu-central-1"
+aws_az1 = "euc1-az1"
+aws_az2 = "euc1-az2"
+aws_az3 = "euc1-az3"

--- a/terraform/vars/us.tfvars
+++ b/terraform/vars/us.tfvars
@@ -1,0 +1,5 @@
+aws_region = "us-east-1"
+nxos_url = "https://192.168.0.103"
+aws_az1 = "use1-az1"
+aws_az2 = "use1-az3"
+aws_az3 = "use1-az3"


### PR DESCRIPTION
This PR:
- provides a dev container that we can use as a common dev environment:
  - OpenTofu version 1.8.1
  - Ansible 2.17.0
  - Python 3.12.7
- modifies .tf files to use variables as a means of connecting dependencies
- breaks .tf variables out into values files

To test:
- in a dev environment that has OpenTofu (or Terraform) and Ansible, run the following:
```
export TF_VAR_my_public_ip=<your-public-IP>
TF_VARS_ tofu plan --var-file vars/eu.tfvars 
```
- you should see a plan generated that depicts the expected site-to-site VPN connection

**NOTE**: this may remove the existing resources if you already have a previous connection set up.